### PR TITLE
ls-github: fix width; do not assume master branch

### DIFF
--- a/bin/git-ls-github
+++ b/bin/git-ls-github
@@ -9,5 +9,5 @@ do
 '
     log_msg=( $(git log -n 1 master --format="%Cred$line%Creset%n%Cgreen%cr%Creset%n%Creset%s%Creset%n%Cblue[%aN]%Creset%n" -- "$line") );
     unset IFS
-    printf "%-30.30s %-20s %s %s\n" "${log_msg[0]}" "${log_msg[1]}" "${log_msg[2]}" "${log_msg[3]}"
+    printf "%-30.30s %-21s %s %s\n" "${log_msg[0]}" "${log_msg[1]}" "${log_msg[2]}" "${log_msg[3]}"
 done

--- a/bin/git-ls-github
+++ b/bin/git-ls-github
@@ -3,11 +3,10 @@
 # show a list of files, latest commit checksum, and subject of latest commit
 # kind of like the github file view
 
-git ls-files | grep -v \/ | while read line ;
-do
+git ls-files | grep -vF '/' | while read file; do
     IFS='
 '
-    log_msg=( $(git log -n 1 HEAD --format="%Cred$line%Creset%n%Cgreen%cr%Creset%n%Creset%s%Creset%n%Cblue[%aN]%Creset%n" -- "$line") );
+    log_msg=( $(git log -n 1 HEAD --format="%Cred$file%Creset%n%Cgreen%cr%Creset%n%Creset%s%Creset%n%Cblue[%aN]%Creset%n" -- "$file") )
     unset IFS
     printf "%-30.30s %-21s %s %s\n" "${log_msg[0]}" "${log_msg[1]}" "${log_msg[2]}" "${log_msg[3]}"
 done

--- a/bin/git-ls-github
+++ b/bin/git-ls-github
@@ -7,7 +7,7 @@ git ls-files | grep -v \/ | while read line ;
 do
     IFS='
 '
-    log_msg=( $(git log -n 1 master --format="%Cred$line%Creset%n%Cgreen%cr%Creset%n%Creset%s%Creset%n%Cblue[%aN]%Creset%n" -- "$line") );
+    log_msg=( $(git log -n 1 HEAD --format="%Cred$line%Creset%n%Cgreen%cr%Creset%n%Creset%s%Creset%n%Cblue[%aN]%Creset%n" -- "$line") );
     unset IFS
     printf "%-30.30s %-21s %s %s\n" "${log_msg[0]}" "${log_msg[1]}" "${log_msg[2]}" "${log_msg[3]}"
 done


### PR DESCRIPTION
the `LICENSE` line appeared to be unaligned:

<pre>
[~/scm/eventum/rpc (pr/1)★] ➔ git-ls-github
.gitattributes         12 months ago exclude tests from git export [Elan Ruusamäe]
.gitignore             12 months ago ignore .php_cs.cache [Elan Ruusamäe]
.php_cs                12 months ago setup php-cs-fixer [Elan Ruusamäe]
.travis.yml            12 months ago setup travis [Elan Ruusamäe]
AUTHORS                12 months ago cleanup; update year [Elan Ruusamäe]
LICENSE                3 years ago  Add LICENSE and README [Elan Ruusamäe]
README.md              2 years, 4 months ago Update README.md [Elan Ruusamäe]
XMLRPC.md              2 years, 4 months ago updated methods help [Elan Ruusamäe]
composer.json          12 months ago replace xmlrpc implementation with phpxmlrpc/phpxmlrpc [Elan Ruusamäe]
phpunit.xml            12 months ago setup phpunit [Elan Ruusamäe]
[~/scm/eventum/rpc (pr/1)★] ➔
</pre>

```
[~/scm/eventum/rpc (pr/1)★] ➔ git-ls-github
.gitattributes         12 months ago exclude tests from git export [Elan Ruusamäe]
.gitignore             12 months ago ignore .php_cs.cache [Elan Ruusamäe]
.php_cs                12 months ago setup php-cs-fixer [Elan Ruusamäe]
.travis.yml            12 months ago setup travis [Elan Ruusamäe]
AUTHORS                12 months ago cleanup; update year [Elan Ruusamäe]
LICENSE                3 years ago   Add LICENSE and README [Elan Ruusamäe]
README.md              2 years, 4 months ago Update README.md [Elan Ruusamäe]
XMLRPC.md              2 years, 4 months ago updated methods help [Elan Ruusamäe]
composer.json          12 months ago replace xmlrpc implementation with phpxmlrpc/phpxmlrpc [Elan Ruusamäe]
phpunit.xml            12 months ago setup phpunit [Elan Ruusamäe]
[~/scm/eventum/rpc (pr/1)★] ➔
```

however it needs more work to guess widths properly, but at least the other commit makes not assume `master` branch.